### PR TITLE
deleted the waiting for calls comment on the emprty dashboard

### DIFF
--- a/app/javascript/components/filter-call.js
+++ b/app/javascript/components/filter-call.js
@@ -19,7 +19,9 @@ const handleCallClick = (event) => {
 
 const initCallFiltering = () => {
   const callCards = document.querySelectorAll('.call-card');
-  filterCall(callCards[0].dataset.callId);
+
+  if (callCards.length > 0) filterCall(callCards[0].dataset.callId);
+
   callCards.forEach(call => call.addEventListener('click', handleCallClick ))
 
   window.handleCallClick = handleCallClick;

--- a/app/views/hospitals/dashboard.html.erb
+++ b/app/views/hospitals/dashboard.html.erb
@@ -7,12 +7,8 @@
   <div class="content">
 
     <div class="call-info" id="call-info">
-      <% if @hospital.calls.any? %>
-        <% @hospital.calls.each do |call| %>
-          <%= render "calls/show", call: call %>
-        <% end %>
-      <% else %>
-        <h2 class = "waiting for call">Waiting for Calls...</h2>
+      <% @hospital.calls.each do |call| %>
+        <%= render "calls/show", call: call %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
deleted the waiting for calls comment on the empty dashboard. This was blocking the new call from appearing on a blank dashboard.